### PR TITLE
Use canvas rendering

### DIFF
--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -32,7 +32,8 @@ export default function(props){
 			<MapContainer
 				zoom={zoom} minZoom={10} maxZoom={16}
 				maxBoundsViscosity={0.25}
-				gestureHandling={true}>
+				gestureHandling={true}
+				preferCanvas={true}>
 				<MapStateProbe
 					setZoom={setZoom}
 					bounds={city.bounds}/>


### PR DESCRIPTION
It's not at all clear to me that this is a performance improvement. It is advertised as at least potentially speeding things up significantly for large layers, but parking in Toronto is still a real beast. 

The better approach here may just be to cut very small parking lots out of the dataset. 