### PR TITLE
Fetch osm data  - only what's needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "html-webpack-plugin": "^5.0.0",
         "less": "^4.1.1",
         "less-loader": "^8.0.0",
+        "node-fetch": "^3.2.0",
         "style-loader": "^2.0.0",
         "webpack": "^5.21.2",
         "webpack-cli": "^4.5.0",
@@ -2373,6 +2374,15 @@
         "d3-time": "1 - 2"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -2703,6 +2713,29 @@
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
     },
+    "node_modules/fetch-blob": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -2731,6 +2764,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -3582,6 +3627,43 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+      "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -4716,6 +4798,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webpack": {
@@ -6863,6 +6954,12 @@
         "d3-time": "1 - 2"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -7112,6 +7209,16 @@
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
     },
+    "fetch-blob": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+      "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -7131,6 +7238,15 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fs.realpath": {
@@ -7772,6 +7888,23 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+      "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
+      "dev": true,
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-releases": {
@@ -8643,6 +8776,12 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+      "dev": true
     },
     "webpack": {
       "version": "5.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/preset-env": "^7.12.13",
         "@babel/preset-react": "^7.12.13",
         "babel-loader": "^8.2.2",
+        "child_process": "^1.0.2",
         "clean-webpack-plugin": "^3.0.0",
         "css-loader": "^5.0.2",
         "html-webpack-plugin": "^5.0.0",
@@ -1977,6 +1978,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=",
+      "dev": true
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.2",
@@ -6632,6 +6639,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=",
+      "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-env": "^7.12.13",
     "@babel/preset-react": "^7.12.13",
     "babel-loader": "^8.2.2",
+    "child_process": "^1.0.2",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.2",
     "html-webpack-plugin": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "html-webpack-plugin": "^5.0.0",
     "less": "^4.1.1",
     "less-loader": "^8.0.0",
+    "node-fetch": "^3.2.0",
     "style-loader": "^2.0.0",
     "webpack": "^5.21.2",
     "webpack-cli": "^4.5.0",

--- a/src/data/.gitignore
+++ b/src/data/.gitignore
@@ -1,1 +1,2 @@
 data-sources/national-data/
+data-sources/osm-data/

--- a/src/data/data-prep-utils/.gitignore
+++ b/src/data/data-prep-utils/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+temp

--- a/src/data/data-prep-utils/.gitignore
+++ b/src/data/data-prep-utils/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-temp

--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -1,0 +1,43 @@
+import fetch from 'node-fetch'
+import { writeFileSync } from 'fs'
+
+// osm_id's
+const cityRelations = [
+	3227127, // calgary
+	2564500, // edmonton
+	9344588, // halifax regional municipality
+	7034910, // hamilton
+	8508277, // montreal urban agglomeration
+	4136816, // ottawa
+	324211,  // toronto
+	1852574, // vancouver
+	2221062, // victoria
+	1790696  // winnipeg
+]
+
+for ( const osm_id of cityRelations ){
+	console.log(osm_id)
+	await getData(osm_id);
+}
+
+async function getData(osm_rel_id){
+	const query = `
+		[out:json];
+		rel(${osm_rel_id});
+		out body;
+	`
+	const options = { 
+		method: 'post',
+		headers: {
+			'content-type': 'application/x-www-form-urlencoded'
+		},
+		body: new URLSearchParams({ data: query }).toString()
+	};
+	await fetch('https://overpass-api.de/api/interpreter',options)
+		.then( response => response.json() )
+		.then(data => {
+			writeFileSync(`temp/${osm_rel_id}.json`,JSON.stringify(data))
+		} )
+}
+
+console.log('Done!')

--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -18,6 +18,8 @@ const cityRelations = [
 for ( const osm_id of cityRelations ){
 	console.log(`fetching data for ${osm_id}`)
 	await getData(osm_id);
+	console.log('waiting 60s before next request')
+	await new Promise(resolve => setTimeout(resolve, 60000));
 }
 
 async function getData(osm_rel_id){

--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch'
 import { writeFileSync } from 'fs'
+import { execSync } from 'child_process'
 
 // osm_id's
 const cityRelations = [
@@ -49,7 +50,15 @@ async function getData(osm_rel_id){
 	await fetch('https://overpass-api.de/api/interpreter',options)
 		.then( response => response.text() )
 		.then( data => {
-			writeFileSync( `../data-sources/osm-data/${osm_rel_id}.osm`,data )
+			const dir = '../data-sources/osm-data'
+			const xmlFilePath = `${dir}/${osm_rel_id}.osm`
+			const pbfFilePath = `${dir}/${osm_rel_id}.pbf`
+			writeFileSync( xmlFilePath, data )
+			try {
+				execSync(`osmconvert ${xmlFilePath} -o=${pbfFilePath}`)
+			} catch {
+				console.log('there may have been an error converting to pbf')
+			}
 		} )
 }
 

--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -22,7 +22,7 @@ for ( const osm_id of cityRelations ){
 
 async function getData(osm_rel_id){
 	const query = `
-		[out:json][timeout:100];
+		[out:xml][timeout:100];
 		rel(${osm_rel_id}); map_to_area->.bnd;
 		(
 		  way[highway=cycleway](area.bnd);
@@ -45,9 +45,9 @@ async function getData(osm_rel_id){
 		body: new URLSearchParams({ data: query }).toString()
 	};
 	await fetch('https://overpass-api.de/api/interpreter',options)
-		.then( response => response.json() )
-		.then(data => {
-			writeFileSync(`../data-sources/osm-data/${osm_rel_id}.json`,JSON.stringify(data))
+		.then( response => response.text() )
+		.then( data => {
+			writeFileSync( `../data-sources/osm-data/${osm_rel_id}.osm`,data )
 		} )
 }
 

--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -16,15 +16,26 @@ const cityRelations = [
 ]
 
 for ( const osm_id of cityRelations ){
-	console.log(osm_id)
+	console.log(`fetching data for ${osm_id}`)
 	await getData(osm_id);
 }
 
 async function getData(osm_rel_id){
 	const query = `
-		[out:json];
-		rel(${osm_rel_id});
+		[out:json][timeout:100];
+		rel(${osm_rel_id}); map_to_area->.bnd;
+		(
+		  way[highway=cycleway](area.bnd);
+		  way[bicycle=designated](area.bnd);
+		  way[~"cycleway"~"crossing|lane|share|shoulder|track|yes"](area.bnd);
+		  nwr[landuse](area.bnd);
+		  nwr[natural~"wood|forest|beach|scrub|fell|heath|moor|grassland"](area.bnd);
+		  nwr[leisure~"park|nature|playground|garden|grass|pitch|common"](area.bnd);
+		  nwr[amenity=parking][parking!~"underground|multi|rooftop"](area.bnd);
+		);
 		out body;
+		>;
+		out skel qt;
 	`
 	const options = { 
 		method: 'post',

--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -47,7 +47,7 @@ async function getData(osm_rel_id){
 	await fetch('https://overpass-api.de/api/interpreter',options)
 		.then( response => response.json() )
 		.then(data => {
-			writeFileSync(`temp/${osm_rel_id}.json`,JSON.stringify(data))
+			writeFileSync(`../data-sources/osm-data/${osm_rel_id}.json`,JSON.stringify(data))
 		} )
 }
 


### PR DESCRIPTION
This is a node.js script for fetching all the OSM data from overpass. Overpass query limits mean that it will likely throw an error after a few requests, but you can just comment out some of the IDs and rerun again after waiting a few minutes. 

Total data size for all cities, as JSON: ~225MB