### PR TITLE
grey out charging station buttons

### DIFF
--- a/src/Legend/OverLayer.jsx
+++ b/src/Legend/OverLayer.jsx
@@ -102,27 +102,32 @@ const paradigms = {
 			{
 				key: 'E1',
 				label: 'Electric (E1)',
-				icon: ChargingStation
+				icon: ChargingStation,
+				dataAvailable: (city)=>!city.data?.improve?.missing?.includes('e1')
 			},
 			{
 				key: 'E2',
 				label: 'Electric (E2)',
-				icon: ChargingStation
+				icon: ChargingStation,
+				dataAvailable: (city)=>!city.data?.improve?.missing?.includes('e2')
 			},
 			{
 				key: 'E3',
 				label: 'Electric (E3/DC)',
-				icon: ChargingStation
+				icon: ChargingStation,
+				dataAvailable: (city)=>!city.data?.improve?.missing?.includes('e3')
 			},
 			{
 				key: 'CNG',
 				label: 'Compressed Natural Gas',
-				icon: ChargingStation
+				icon: ChargingStation,
+				dataAvailable: (city)=>!city.data?.improve?.missing?.includes('cng')
 			},
 			{
 				key: 'LPG',
 				label: 'Propane',
-				icon: ChargingStation
+				icon: ChargingStation,
+				dataAvailable: (city)=>!city.data?.improve?.missing?.includes('propane')
 			}
 		]
 	}

--- a/src/data/Edmonton/data.js
+++ b/src/data/Edmonton/data.js
@@ -17,6 +17,7 @@ export default {
 		parking: require('./shift/lu_parking.topojson')
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['e1']
 	}
 }

--- a/src/data/Halifax/data.js
+++ b/src/data/Halifax/data.js
@@ -12,7 +12,8 @@ export default {
 		}
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['e1','cng','propane']
 	},
 	shift: {
 		bikePaths: require('./shift/bike.topojson'),

--- a/src/data/Hamilton/data.js
+++ b/src/data/Hamilton/data.js
@@ -19,6 +19,7 @@ export default {
 		parking: require('./shift/lu_parking.topojson')
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['e1']
 	}
 }

--- a/src/data/Ottawa/data.js
+++ b/src/data/Ottawa/data.js
@@ -14,7 +14,8 @@ export default {
 		}
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['e1']
 	},
 	shift: {
 		bikePaths: require('./shift/bike.topojson'),

--- a/src/data/Toronto/data.js
+++ b/src/data/Toronto/data.js
@@ -19,6 +19,7 @@ export default {
 		parking: require('./shift/lu_parking.topojson')
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['e1']
 	}
 }

--- a/src/data/Victoria/data.js
+++ b/src/data/Victoria/data.js
@@ -12,7 +12,8 @@ export default {
 		}
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['e1','e3']
 	},
 	shift: {
 		bikePaths: require('./shift/bike.topojson'),

--- a/src/data/Winnipeg/data.js
+++ b/src/data/Winnipeg/data.js
@@ -13,7 +13,8 @@ export default {
 		}
 	},
 	improve: {
-		fuelStations: require('./improve/alt_fuel_stations.topojson')
+		fuelStations: require('./improve/alt_fuel_stations.topojson'),
+		missing: ['cng']
 	},
 	shift: {
 		bikePaths: require('./shift/bike.topojson'),


### PR DESCRIPTION
fixes #61 

Not my best coding, but it gets the job done quickly. We will need to manually check the data for Halifax that will be pulled with the new boundary and see if any E1, CNG, or propane charging stations turn up. If they do, we need to manually set them to not-missing. 