### PR TITLE
Change overpass query; use default ordering

### DIFF
--- a/src/data/data-prep-utils/fetch-osm.mjs
+++ b/src/data/data-prep-utils/fetch-osm.mjs
@@ -36,9 +36,8 @@ async function getData(osm_rel_id){
 		  nwr[leisure~"park|nature|playground|garden|grass|pitch|common"](area.bnd);
 		  nwr[amenity=parking][parking!~"underground|multi|rooftop"](area.bnd);
 		);
-		out body;
-		>;
-		out skel qt;
+		(._;>;);
+		out body qt;
 	`
 	const options = { 
 		method: 'post',


### PR DESCRIPTION
A few extra MB, but this just may fix the problem. The query as I'd written it was structured similarly to the one we had a problem with before. All of the bike-related queries looked only for ways, but the landuse ones allowed for relations which is where we had the problems. Perhaps why the bike data seemed to work fine? I'm still not sure what the actual problem is here. 

Anyway, I've combined the output into a single statement so overpass can determine the order. Maybe that will fix things; it's worth a try anyway. 